### PR TITLE
Change `learned` command

### DIFF
--- a/scripts/memory.coffee
+++ b/scripts/memory.coffee
@@ -64,9 +64,7 @@ module.exports = (robot) ->
     res.respond "I will try to remember something for you."
 
   robot.respond /learned/, (res) ->
-    res.send "Here's what I learned:"
-    res.send "*\"#{thought}\"*: #{thoughts[thought]}" for thought of thoughts
-    res.emote "Fin"
+    res.reply "check out my brain at http://rampant-stove.surge.sh/"
 
   robot.respond /\? learned$/, (res) ->
     res.send " * learned // in a Direct Message"


### PR DESCRIPTION
Unwitting people were very prone to spam channels by invoking the learned command.
Since I've finally built a frontend for the redis instance with all the data, I thought we could link there instead.
