### PR TITLE
Cleans up `memory` script

### DIFF
--- a/scripts/memory.coffee
+++ b/scripts/memory.coffee
@@ -6,17 +6,12 @@
 #
 # Commands:
 #   hubot learn "<key name>" means <value> - Get Hubot to memorize something new
-#   !learn "<key name>" means <value> - Get Hubot to memorize something new
 #   hubot relearn "<key name>" means <value> - Overwrite something that Hubot learned before
-#   hubot ? - Lists all the things that Hubot has learned
+#   hubot learned - Check all the things Hubot as learned so far
 
 module.exports = (robot) ->
   redisUrl = process.env.REDISCLOUD_URL
   thoughts = null
-
-  robot.respond /\?$/, (res) ->
-    res.reply "Here are the commands I know: `learn`, `remember`, `learned`, `relearn`"
-    res.reply "To learn more about the command ask me `? <command>`"
 
   actuallyLearnMethod = (res, key, value) ->
     thoughts[key] = value
@@ -34,19 +29,9 @@ module.exports = (robot) ->
     [_, key, value] = res.match
     actuallyLearnMethod(res, key, value)
 
-  robot.hear /^!learn "([^"]+)" (.+)$/i, (res)-> learnMethod(res)
   robot.respond /learn "([^"]+)" (.+)$/i, (res)-> learnMethod(res)
 
   robot.respond /relearn "([^"]+)" (.+)$/i, (res)-> relearnMethod(res)
-
-  robot.respond /\? learn$/, (res) ->
-    res.send "> @tombot learn \"quotes-delimited key\" the thing you want me to remember"
-    res.send "> !learn \"quotes-delimited key\" the things you want me to remember"
-    res.reply "I will learn something new for you."
-
-  robot.respond /\? relearn$/, (res) ->
-    res.send "* @tombot relearn \"quotes-delimited key\" the thing you want me to remember"
-    res.reply "I will replace what I have learned with the new information."
 
   rememberMethod = (res) ->
     [_, match] = res.match
@@ -55,23 +40,12 @@ module.exports = (robot) ->
     else
       res.send "sorry, I don't know this :("
 
-  robot.hear /^!remember "([^"]+)"/, rememberMethod
   robot.respond /.*remember "([^"]+)".*/, rememberMethod
-
-  robot.respond /\? remember/, (res) ->
-    res.send "> `@tombot remember \"quotes-delimited key`\""
-    res.send "> `!remember \"quotes-delimited key`\""
-    res.respond "I will try to remember something for you."
 
   robot.respond /learned/, (res) ->
     res.send "Here's what I learned:"
     res.send "*\"#{thought}\"*: #{thoughts[thought]}" for thought of thoughts
     res.emote "Fin"
-
-  robot.respond /\? learned$/, (res) ->
-    res.send " * learned // in a Direct Message"
-    res.reply "I will tell you every single thing I've learned."
-    res.reply "Since it might be a lot please only ask me this in a Direct Message"
 
   robot.brain.on 'loaded', ->
     thoughts = robot.brain.data.thoughts


### PR DESCRIPTION
- Removes !command version of commands.
- Removes `?` and `? <command>`. Unnecessary due to `hubot-help`.
- Adds `learned` to commands documentation for `hubot-help`.
